### PR TITLE
검색 리스트 아이템 엄지척 개수 렌더링 / 연속 엄지척 되는 버그 해결

### DIFF
--- a/client/src/common/Form.js
+++ b/client/src/common/Form.js
@@ -9,6 +9,46 @@ import Footer from './Footer';
 import ThemeContext from '../contexts/ThemeContext';
 import MediaQuery from 'react-responsive';
 
+const Toggler = ({ togglerRef, onClick }) => (
+  <div
+    ref={togglerRef}
+    style={{
+      display: 'flex',
+      flexDirection: 'column',
+      position: 'relative',
+      width: 40,
+      height: 75,
+      cursor: 'pointer',
+      gap: 5
+    }}
+    onClick={onClick}
+  >
+    <div
+      style={{
+        width: 30,
+        height: 30,
+        fontSize: 30,
+        padding: 5,
+        // color: theme.main,
+        textAlign: 'center'
+      }}
+    >
+      <RiPencilFill />
+    </div>
+    <div
+      style={{
+        width: 30,
+        height: 30,
+        fontSize: 30,
+        padding: 5,
+        textAlign: 'center'
+      }}
+    >
+      <RiEye2Line />
+    </div>
+  </div>
+);
+
 const ResponsiveImage = ({ src }) => (
   <div style={{ width: '2rem', justifyContent: 'center', display: 'flex' }}>
     <img src={src} width={20} />
@@ -87,43 +127,7 @@ export default function Form({ post, setPost, WriteButton }) {
       <MediaQuery minWidth={780}>
         <div style={{ position: 'sticky', top: 0 }}>
           <div style={{ position: 'absolute', left: -50, top: 60 }}>
-            <div
-              ref={togglerRef}
-              style={{
-                display: 'flex',
-                flexDirection: 'column',
-                position: 'relative',
-                width: 40,
-                height: 75,
-                cursor: 'pointer',
-                gap: 5
-              }}
-              onClick={onClick}
-            >
-              <div
-                style={{
-                  width: 30,
-                  height: 30,
-                  fontSize: 30,
-                  padding: 5,
-                  color: theme.main,
-                  textAlign: 'center'
-                }}
-              >
-                <RiPencilFill />
-              </div>
-              <div
-                style={{
-                  width: 30,
-                  height: 30,
-                  fontSize: 30,
-                  padding: 5,
-                  textAlign: 'center'
-                }}
-              >
-                <RiEye2Line />
-              </div>
-            </div>
+            <Toggler togglerRef={togglerRef} />
             <div
               style={{
                 margin: '20px 0',

--- a/client/src/page/ReadPost.js
+++ b/client/src/page/ReadPost.js
@@ -39,6 +39,7 @@ const StyledThumbsUpText = styled.span`
   color: white;
   top: -30px;
   left: 0px;
+  text-shadow: 0px 0px 3px black;
 `;
 
 export default function Post() {
@@ -46,9 +47,10 @@ export default function Post() {
   const userId = 'jsi06138';
   const [post, setPost] = useState({});
   const { title, platform, subtitle, language, content, writeDate, writerId } = post;
-  const [liker, setLiker] = useState([]);
-  const [like, setLike] = useState(false);
+  const [likeCount, setLikeCount] = useState(0);
+  const [isLiker, setIsLiker] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [clickLike, setClickLike] = useState(false);
 
   const theme = useContext(ThemeContext);
 
@@ -57,23 +59,26 @@ export default function Post() {
       setIsLoading(true);
       const res = await fetchPost_GET(id);
       setPost(res.post);
-      setLiker(res.liker);
+      setLikeCount(res.liker.length);
+      setIsLiker(res.liker.some(({ userId: id }) => userId === id));
       setIsLoading(false);
     })();
   }, []);
 
   const onClickLike = () => {
-    if (liker.some(({ userId }) => userId === 'jsi06138')) {
+    if (isLiker) {
       (async () => {
+        setIsLiker(false);
+        setLikeCount(likeCount - 1);
+        setClickLike(false);
         const res = await fetchLike_DELETE(id, userId);
-        setLiker(res);
-        setLike(0);
       })();
     } else {
       (async () => {
+        setIsLiker(true);
+        setLikeCount(likeCount + 1);
+        setClickLike(true);
         const res = await fetchLike_POST(id, userId);
-        setLiker(res);
-        setLike(1);
       })();
     }
   };
@@ -111,17 +116,17 @@ export default function Post() {
         <MarkDownPreview source={content} />
         <div style={{ fontSize: '2.5rem', position: 'relative' }}>
           {' '}
-          {like === 1 && (
+          {clickLike && (
             <StyledThumbsUpText>
               <RiThumbUpFill color={theme.main} /> 좋은 솔루션이에요
             </StyledThumbsUpText>
           )}
           <RiThumbUpFill
             onClick={onClickLike}
-            color={liker.some(({ userId }) => userId === 'jsi06138') ? theme.main : 'white'}
+            color={isLiker ? theme.main : 'white'}
             style={{ cursor: 'pointer' }}
           />{' '}
-          {liker.length}
+          {likeCount}
           <RiChat1Fill color={theme.main} /> 0{' '}
         </div>
       </div>

--- a/client/src/post/Post.js
+++ b/client/src/post/Post.js
@@ -22,7 +22,7 @@ const StyledPost = styled.div`
 
 // StyledPost를 젤 바깥으로 빼기
 export default function Post({ post }) {
-  const { id, title, subtitle, platform, language, writerId, writeDate } = post;
+  const { id, title, subtitle, platform, language, writerId, writeDate, likeCount } = post;
 
   const theme = useContext(ThemeContext);
 
@@ -67,7 +67,7 @@ export default function Post({ post }) {
           </div>
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <RiThumbUpFill color={theme.main} size="2rem" />
-            <strong>8</strong>
+            <strong>{likeCount}</strong>
           </div>
         </div>
       </StyledPost>

--- a/server/routes/like.js
+++ b/server/routes/like.js
@@ -8,7 +8,11 @@ router.post('/', async (req, res, next) => {
     const { postId, userId } = req.body;
     await createLike(req.body);
     const liker = await findLiker(postId);
-    res.json(liker);
+    const isLiker = liker.some(({ userId: id }) => userId === id);
+
+    setTimeout(() => {
+      res.json({ likeCount: liker.length, isLiker });
+    }, 3000);
   } catch (error) {
     console.log(error);
     res.json({ msg: '실패!' });
@@ -21,7 +25,11 @@ router.delete('/', async (req, res, next) => {
     const { postId, userId } = req.body;
     await deleteLike(req.body);
     const liker = await findLiker(postId);
-    res.json(liker);
+    const isLiker = liker.some(({ userId: id }) => userId === id);
+
+    setTimeout(() => {
+      res.json({ likeCount: liker.length, isLiker });
+    }, 3000);
   } catch (error) {
     res.json({ msg: '실패!' });
   }


### PR DESCRIPTION
개선이 필요한 작업들의 task들 일부 완료

## 📚  개선 요구 작업
###
- [x] 검색 리스트 아이템의 엄지척 개수도 fetch
for ... of 문을 사용해 await 키워드를 유효하게 만들 수 있었다.! (for문내 비동기 작업들이 끝난 후 for문 다음 코드로 이동하게 됨) /
또, Promise api 중 all 이라는 함수를 사용해 비동기 작업 들을 제어할 수도 있다.

``` javascript
// api server 파트
  for(const post of posts) {
    post.writeDate = formatDate(post.writeDate);
    post.likeCount = (await findLiker(post._id)).length;
  }
```
- [x] 클라이언트에서 연속으로 엄지척 가능한 버그 해결

```문제``` 2번 연속 엄지척이 가능한 문제 말고도, 서버 응답 속도가 느린 경우에 늦게 렌더링이되어 ux를 해칠 수 있었다.
```해결안``` 기존 컴포넌트의 상태에서 새롭게 추가된 상태가 있다. 
현재 사용자가 liker인지 아닌지와 엄지척 개수 데이터인데, 이들은 처음 컴포넌트가 마운트됐을 때 서버로 부터 얻게되고
state가 변경될 경우에는 client 단에서 바로바로 변경해주도록 했다.
이렇게 해서 발견한 2개의 문제를 해결할 수 있었다.

- [x] 엄지척 text 그림자 (흰배경에도 잘 보이게)


#28 