### PR TITLE
Refresh token 구현, useAuthentication 훅 적용

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -5,24 +5,51 @@ import ReadPost from './page/ReadPost';
 import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
 import { ThemeContextProvider } from './contexts/ThemeContext';
 import { ModalContextProvider } from './contexts/ModalContext';
-import { UserContextProvider } from './contexts/UserContext';
+import UserContext, { UserContextProvider } from './contexts/UserContext';
 import SignUp from './page/SignUp';
+import { useContext, useEffect } from 'react';
+import useAuthorization from './hooks/useAuthorizaiton';
+import { fetchAutoSignin_GET } from './api/authApi';
+
+const MyComponent = ({ children }) => {
+  const [isLoggedIn, setIsLoggedIn, userData, setUserData] = useContext(UserContext);
+  const authorization = useAuthorization();
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const accessToken = await authorization();
+        if (!accessToken) return;
+        const res = await fetchAutoSignin_GET(accessToken);
+        const { userId, msg } = await res.json();
+        setUserData({ ...userData, userId: userId });
+        setIsLoggedIn(true);
+      } catch (error) {
+        console.log(error);
+      }
+    })();
+  }, []);
+
+  return <>{children}</>;
+};
 
 export default function App() {
   return (
     <ThemeContextProvider>
       <ModalContextProvider>
         <UserContextProvider>
-          <Router>
-            <Switch>
-              <Route path="/" exact component={Home} />
-              <Route path="/write" exact component={WritePost} />
-              <Route path="/edit" exact component={EditPost} />
-              <Route path="/post" exact component={ReadPost} />
-              <Route path="/signup" exact component={SignUp} />
-              {/* edit/:postsId */}
-            </Switch>
-          </Router>
+          <MyComponent>
+            <Router>
+              <Switch>
+                <Route path="/" exact component={Home} />
+                <Route path="/write" exact component={WritePost} />
+                <Route path="/edit" exact component={EditPost} />
+                <Route path="/post" exact component={ReadPost} />
+                <Route path="/signup" exact component={SignUp} />
+                {/* edit/:postsId */}
+              </Switch>
+            </Router>
+          </MyComponent>
         </UserContextProvider>
       </ModalContextProvider>
     </ThemeContextProvider>

--- a/client/src/api/authApi.js
+++ b/client/src/api/authApi.js
@@ -44,7 +44,7 @@ const fetchSignup_POST = async (userNumber, platform, nickname, description, pro
 
 const fetchRefreshToken_GET = async (refreshToken) => {
   try {
-    const res = await fetch('/api/auth/refreshToken', {
+    const res = await fetch('/api/auth/updateToken', {
       headers: {
         Authorization: `Bearer ${refreshToken}`
       }

--- a/client/src/contexts/UserContext.js
+++ b/client/src/contexts/UserContext.js
@@ -1,7 +1,5 @@
-import { useEffect } from 'react';
-import { createContext, useState } from 'react';
-import { fetchAutoSignin_GET, fetchRefreshToken_GET } from '../api/authApi';
-
+import { createContext, useDebugValue, useEffect, useState } from 'react';
+import { fetchAutoSignin_GET } from '../api/authApi';
 const UserContext = createContext();
 
 function UserContextProvider({ children }) {
@@ -9,33 +7,9 @@ function UserContextProvider({ children }) {
   const [userData, setUserData] = useState({
     api_accessToken: null,
     userId: null,
-    accessToken: null
+    accessToken: window.localStorage.getItem('access_token') || null,
+    refreshToken: window.localStorage.getItem('refresh_token') || null
   });
-
-  useEffect(() => {
-    (async () => {
-      try {
-        // 갖고 있는 access token이 있다면 user 로그인 정보를 업데이트한다.
-        const accessToken = window.localStorage.getItem('access_token');
-        if (!accessToken) return;
-        const res = await fetchAutoSignin_GET(accessToken);
-        const { userId, msg } = await res.json();
-
-        const refreshToken = window.localStorage.getItem('refresh_token');
-
-        if (msg === '토큰 만료') {
-          const res = await fetchRefreshToken_GET(refreshToken);
-          const { accessToken: new_accessToken, refreshToken: new_refreshToken } = await res.json();
-          window.localStorage.setItem('access_token', new_accessToken);
-          if (new_refreshToken) window.localStorage.setItem('refresh_token', new_refreshToken);
-        }
-        setUserData({ userId: userId, accessToken });
-        setIsLoggedIn(true);
-      } catch (error) {
-        console.log(error);
-      }
-    })();
-  }, []);
 
   return (
     <UserContext.Provider value={[isLoggedIn, setIsLoggedIn, userData, setUserData]}>

--- a/client/src/hooks/useAuthorizaiton.js
+++ b/client/src/hooks/useAuthorizaiton.js
@@ -1,0 +1,33 @@
+import { useContext } from 'react';
+import UserContext from '../contexts/UserContext';
+
+export default function useAuthorization() {
+  const [_, __, userData, setUserData] = useContext(UserContext);
+
+  // 인가를 위한 함수로 성공적으로 token이 발급된 경우 token을 발급
+  // 검사 실패할 경우 null 발급
+  const authorization = async () => {
+    if (!userData.accessToken || !userData.refreshToken) return;
+
+    const res = await fetch('/api/auth/verifyToken', {
+      headers: { Authorization: `Bearer ${userData.accessToken}` }
+    });
+    if (res.status !== 401) return userData.accessToken;
+    const { msg, error } = await res.json();
+
+    if (error === 'expired token') {
+      // access token 유효성 검증 실패이유가 토큰 만료일 때
+      const res = await fetch('/api/auth/refreshToken', {
+        headers: { authorization: `Bearer ${userData.refreshToken}` }
+      });
+      const { accessToken: new_acccessToken } = await res.json();
+      setUserData({ ...userData, new_acccessToken });
+      window.localStorage.setItem('access_token', new_acccessToken);
+      return new_acccessToken;
+    }
+    // access token 유효성 검증 실패이유가 토큰 만료 외의 이유일 때 (올바르지 않은 접근)
+    return null;
+  };
+
+  return authorization;
+}

--- a/server/utils.js
+++ b/server/utils.js
@@ -31,8 +31,8 @@ const docsMap = (docs, callback) => (
 
 const generateAccessToken = (userId, userNumber, platform) => {
   try {
-    const token = jwt.sign({ userId, userNumber, platform }, process.env.SECRET_KEY, {
-      expiresIn: '10s'
+    const token = jwt.sign({ userId, userNumber, platform }, process.env.ACCESS_SECRET_KEY, {
+      expiresIn: '5s'
     });
     return token;
   } catch (error) {
@@ -42,9 +42,7 @@ const generateAccessToken = (userId, userNumber, platform) => {
 
 const generateRefreshToken = (userId, userNumber, platform) => {
   try {
-    const token = jwt.sign({ userId, userNumber, platform }, process.env.SECRET_KEY, {
-      expiresIn: '7d'
-    });
+    const token = jwt.sign({ userId, userNumber, platform }, process.env.REFRESH_SECRET_KEY);
     return token;
   } catch (error) {
     throw new Error(error);


### PR DESCRIPTION
## 📚  구현 사항
###
**- client / server 공통 사항**
- [x] Refresh token 요청 및 응답 설계 / 구현
기존 코드에 변경을 줄이고, 컴포넌트 로직을 보다 간단히 하기 위해 인가를 위한 훅을 생성했다.
내부에 authorization는 인가에 성공 시 access token을 반환하고 그렇지 않으면 null을 반환하는 함수다.
``` javascript
import { useContext } from 'react';
import UserContext from '../contexts/UserContext';

export default function useAuthorization() {
  const [_, __, userData, setUserData] = useContext(UserContext);

  const authorization = async () => {
    // 1. access token, refresh token 둘 중에 하나라도 없으면 인가 기능 사용 불가

    // 2. 토큰 유효성 검증

    // 3 - 1. access token 유효성 검증 실패이유가 토큰 만료일 때
    // refresh token과 함께 새로운 access token 요청

    }
    // 3 - 2. access token 유효성 검증 실패이유가 토큰 만료 외의 이유일 때 (올바르지 않은 접근)
    // null을 반환
  };

  return authorization;
}
```

사용 예시 (자동로그인)
``` javascript

  useEffect(() => {
    (async () => {
      try {
        const accessToken = await authorization();
        if (!accessToken) return; // 인가에 실패 !
        const res = await fetchAutoSignin_GET(accessToken);
        ...
    })();
  }, []);
```

**server**
- [x] access token, refresh token 각각을 위한 secret key 나눠서 생성 
  이전에 access token과 refresh token 생성 시 같은 secret key를 이용했었다.
  이 경우 두 token이 구분이 되지 않으며, access token을 탈취해서 refresh token으로 이용할 수 있다는 것을 피드백 받아
  토큰 종류마다 다른 secret key를 생성했다.