### PR TITLE
풀이 수정, 풀이 삭제 기능 구현

### DIFF
--- a/client/src/common/Form.js
+++ b/client/src/common/Form.js
@@ -85,7 +85,7 @@ const ResponsiveImage = ({ src }) => (
   </div>
 );
 
-export default function Form({ post, setPost, WriteButton }) {
+export default function Form({ post, setPost, Button }) {
   const { title, platform, subtitle, language, content } = post;
   const [toggle, setToggle] = useState(0);
   const togglerRef = useRef(null);
@@ -187,7 +187,7 @@ export default function Form({ post, setPost, WriteButton }) {
       />
       <MediaQuery minWidth={780}>
         <div style={{ textAlign: 'right' }}>
-          <WriteButton />
+          <Button />
         </div>
       </MediaQuery>
       <MediaQuery minWidth={0} maxWidth={750}>
@@ -203,7 +203,7 @@ export default function Form({ post, setPost, WriteButton }) {
               }}
             >
               <Toggler toggle={toggle} onClick={onClick} />
-              <WriteButton />
+              <Button />
             </div>
           </Footer>
         </div>

--- a/client/src/common/Link.js
+++ b/client/src/common/Link.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+import { Link as OldLink } from 'react-router-dom';
+import { useContext } from 'react';
+import ThemeContext from '../contexts/ThemeContext';
+
+const StyledText = styled.span`
+  color: white;
+  font-size: inherit;
+
+  & :hover {
+    text-decoration: underline ${(props) => props.underlineColor};
+  }
+`;
+
+export default function Link({ to, replace, children }) {
+  const theme = useContext(ThemeContext);
+
+  return (
+    <OldLink to={to} replace={replace}>
+      <StyledText underlineColor={theme.main}>{children}</StyledText>
+    </OldLink>
+  );
+}

--- a/client/src/form/fetchApis.js
+++ b/client/src/form/fetchApis.js
@@ -10,7 +10,7 @@ const fetchLanguage_GET = async (keyword, callback) => {
 
 const fetchSolution_GET = async (id) => {
   try {
-    const res = await fetch(`/api/posts?id=${id}`);
+    const res = await fetch(`/api/post?id=${id}`);
     return res.json();
   } catch (error) {
     console.log(error);
@@ -19,7 +19,7 @@ const fetchSolution_GET = async (id) => {
 
 const fetchSolution_POST = (post) => async (accessToken) => {
   try {
-    const res = await fetch('/api/posts', {
+    const res = await fetch('/api/post', {
       method: 'post',
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -37,7 +37,7 @@ const fetchSolution_PUT = (id, post) => async (accessToken) => {
   try {
     delete post._id;
 
-    const res = await fetch(`/api/posts?id=${id}`, {
+    const res = await fetch(`/api/post?id=${id}`, {
       method: 'put',
       headers: {
         Authorization: `Bearer ${accessToken}`,
@@ -51,4 +51,26 @@ const fetchSolution_PUT = (id, post) => async (accessToken) => {
   }
 };
 
-export { fetchLanguage_GET, fetchSolution_GET, fetchSolution_POST, fetchSolution_PUT };
+const fetchSolution_DELETE = (id) => async (accessToken) => {
+  try {
+    const response = await fetch(`/api/post?id=${id}`, {
+      method: 'delete',
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    });
+    const result = await response.json();
+    return result;
+  } catch (err) {
+    console.log(err);
+    return;
+  }
+};
+
+export {
+  fetchLanguage_GET,
+  fetchSolution_GET,
+  fetchSolution_POST,
+  fetchSolution_PUT,
+  fetchSolution_DELETE
+};

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -21,6 +21,10 @@ input {
   background-color: #353535;
 }
 
+a {
+  text-decoration: none;
+}
+
 @media screen and (max-width: 600px) {
   html {
     font-size: 8px;

--- a/server/app.js
+++ b/server/app.js
@@ -40,7 +40,7 @@ app.use((req, res, next) => { // 매핑되는 경로 없을 때
 });
 
 app.listen(PORT, () => {
-w  console.log(`app listening at http://localhost:${PORT}`)
+    console.log(`app listening at http://localhost:${PORT}`)
 });
 
 export default app;

--- a/server/queries/post.js
+++ b/server/queries/post.js
@@ -32,6 +32,15 @@ const updatePost = async (id, data) => {
   }
 };
 
+const deletePost = async (id, writerId) => {
+  try {
+    await Post.deleteOne({ _id: id, writerId });
+    console.log('succefully delete post');
+  } catch (err) {
+    console.log(err);
+  }
+};
+
 /**
  * 해당 키워드 그리고 작성자에 해당하는 포스트 반환
  */
@@ -90,4 +99,4 @@ const countPosts = async (keyword, language, writerId) => {
   }
  }
 
-export { insertPost, updatePost, findPost, findPosts, countPosts, leftPosts };
+export { insertPost, updatePost, deletePost, findPost, findPosts, countPosts, leftPosts };

--- a/server/routes/post.js
+++ b/server/routes/post.js
@@ -1,5 +1,7 @@
 import express from 'express';
-import { findPost } from '../queries/post.js';
+import jwt from 'jsonwebtoken';
+import { insertPost, updatePost, findPost, deletePost } from '../queries/post.js';
+import { findLanguage } from '../queries/language.js';
 import { findLiker } from '../queries/like.js';
 import { docsMap, formatDate } from '../utils.js';
 const router = express.Router();
@@ -7,7 +9,14 @@ const router = express.Router();
 router.get('/', async (req, res) => {
   const { id } = req.query;
   let post = await findPost(id);
+
+  if (post == null) {
+    res.status(200).json({ post: null, liker: null });
+    return;
+  }
+
   const liker = await findLiker(id);
+  
 
   post = docsMap([post], (post) => {
     post.writeDate = formatDate(post.writeDate);
@@ -15,6 +24,90 @@ router.get('/', async (req, res) => {
   });
 
   res.status(200).json({ post: post[0], liker });
+});
+
+// 인가
+router.use((req, res, next) => {
+  try {
+    const accessToken = req.headers['authorization'].split(' ')[1]; 
+    const { userId } = jwt.verify(accessToken, process.env.ACCESS_SECRET_KEY);
+    req.userId = userId;
+    next();
+  } catch (error) {
+    if (name === 'TokenExpiredError') {
+      res.status(401).json({ error: 'expired token' });
+      return;
+    }
+    res.status(401).json({ msg: "서비스를 이용하려면 로그인 또는 회원가입이 필요합니다" });
+  }
+});
+
+
+router.post('/', async (req, res) => {
+  const { userId } = req;
+  const { title, platform, language, content, subtitle } = req.body;
+  const data = {
+    title,
+    platform,
+    language,
+    content,
+    subtitle,
+    writerId: userId, 
+  }
+
+  if (!title || !platform) {
+    res.json({ msg: '문제 링크를 올려주세요' });
+    return;
+  }
+  if (language && (await findLanguage(language)).length === 0) {
+    res.json({ msg: '올바른 언어를 입력하세요' });
+    return;
+  }
+  if (!content) {
+    res.json({ msg: '풀이를 작성해주세요' });
+    return;
+  }
+  const post = await insertPost(data);
+  res.status(201).json({ post, msg: '정상적으로 글이 등록됐습니다' });
+});
+
+router.put('/', async (req, res) => {
+  const { id } = req.query;
+  const { userId } = req;
+  const { title, platform, language, content, subtitle } = req.body;
+  const data = {
+    title,
+    platform,
+    language,
+    content,
+    subtitle,
+    writerId: userId, 
+  }
+
+  if (!title || !platform) {
+    res.json({ msg: '문제 링크를 올려주세요' });
+    return;
+  }
+  if (language && (await findLanguage(language)).length === 0) {
+    res.json({ msg: '올바른 언어를 입력하세요' });
+    return;
+  }
+  if (!content) {
+    res.json({ msg: '풀이를 작성해주세요' });
+    return;
+  }
+  const post = await updatePost(id, data);
+  res.status(201).json({ post, msg: '정상적으로 글이 수정됐습니다' });
+});
+
+
+router.delete('/', async (req, res) => {
+  const { id } = req.query;
+  const { userId } = req;
+
+  // 삭제 요청된 글의 작성자와 요청자가 일치해야함.
+  const post = await deletePost(id, userId);
+  res.status(200).json({ msg: '정상적으로 글이 삭제됐습니다' });
 });
 
 export default router;

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -1,7 +1,5 @@
 import express from 'express';
-import jwt from 'jsonwebtoken';
-import { insertPost, updatePost, findPost, findPosts, countPosts, leftPosts } from '../queries/post.js';
-import { findLanguage } from '../queries/language.js';
+import { findPost, findPosts, countPosts, leftPosts } from '../queries/post.js';
 import {  formatDate } from '../utils.js';
 import { findLiker } from '../queries/like.js';
 const router = express.Router();
@@ -39,80 +37,6 @@ router.get('/search', async (req, res) => {
       leftCount: leftCount - posts.length,
       posts,
     });
-});
-
-// 인가
-router.use((req, res, next) => {
-  try {
-    const accessToken = req.headers['authorization'].split(' ')[1]; 
-    const { userId } = jwt.verify(accessToken, process.env.ACCESS_SECRET_KEY);
-    req.userId = userId;
-    next();
-  } catch (error) {
-    if (name === 'TokenExpiredError') {
-      res.status(401).json({ error: 'expired token' });
-      return;
-    }
-    res.status(401).json({ msg: "서비스를 이용하려면 로그인 또는 회원가입이 필요합니다" });
-  }
-});
-
-
-router.post('/', async (req, res) => {
-  const { userId } = req;
-  const { title, platform, language, content, subtitle } = req.body;
-  const data = {
-    title,
-    platform,
-    language,
-    content,
-    subtitle,
-    writerId: userId, 
-  }
-
-  if (!title || !platform) {
-    res.json({ msg: '문제 링크를 올려주세요' });
-    return;
-  }
-  if (language && (await findLanguage(language)).length === 0) {
-    res.json({ msg: '올바른 언어를 입력하세요' });
-    return;
-  }
-  if (!content) {
-    res.json({ msg: '풀이를 작성해주세요' });
-    return;
-  }
-  const post = await insertPost(data);
-  res.status(201).json({ post, msg: '정상적으로 글이 등록됐습니다' });
-});
-
-router.put('/', async (req, res) => {
-  const { id } = req.query;
-  const { userId } = req;
-  const { title, platform, language, content, subtitle } = req.body;
-  const data = {
-    title,
-    platform,
-    language,
-    content,
-    subtitle,
-    writerId: userId, 
-  }
-
-  if (!title || !platform) {
-    res.json({ msg: '문제 링크를 올려주세요' });
-    return;
-  }
-  if (language && (await findLanguage(language)).length === 0) {
-    res.json({ msg: '올바른 언어를 입력하세요' });
-    return;
-  }
-  if (!content) {
-    res.json({ msg: '풀이를 작성해주세요' });
-    return;
-  }
-  const post = await updatePost(id, data);
-  res.status(201).json({ post, msg: '정상적으로 글이 수정됐습니다' });
 });
 
 export default router;

--- a/server/utils.js
+++ b/server/utils.js
@@ -32,7 +32,7 @@ const docsMap = (docs, callback) => (
 const generateAccessToken = (userId, userNumber, platform) => {
   try {
     const token = jwt.sign({ userId, userNumber, platform }, process.env.ACCESS_SECRET_KEY, {
-      expiresIn: '1h'
+      expiresIn: '30m'
     });
     return token;
   } catch (error) {


### PR DESCRIPTION
## 📚  구현 사항
- [x] **✨ 풀이 삭제 api 구현**
api 서버에서 풀이 삭제 시, 풀이 작성자와 삭제 api 요청자가 같아야 되므로
엔티티의 id 뿐만 아니라 userId를 query에다 전달하도록 api를 구현했다. 
-> 특정 사용자가 본인이 작성하지 않은 게시물 삭제를 요청할 때를 방어할 수 있다.

**- 권한에 따른 기능 사용 제한**
- [x] 작성자 풀이 수정 및 삭제 권한
- 해당글의 수정 및 삭제 버튼 작성자만 보이게
- [x] 비회원 엄지척
- 비회원 클릭불가
- [x] 각 뷰에 접근 권한 제어 (풀이 작성 및 수정 뷰)
- (수정) 해당 풀이의 작성자가 아닌 사용자 접근 제어
- (작성) 비회원 접근 제어

## ✨변경 사항
api 서버에서 단일 Post 관련 기능과 Posts 관련 기능들을 분리하기 위해
기존에 /routes/posts에 있던 post 등록, 수정 로직을 /routes/post로 이동했음.
이에 따라 클라이언트에서 api를 호출하는 fetch api들의 url도 변경됨.

ex) post 등록
```javascript
// 기존
fetch('/api/posts', { ... })

// 변경된 코드
fetch('/api/post', { ... })
```

resolved #24 

## 📌  개선 사항
- 풀이 삭제 후 다른 url로 리다이렉트 시킬 것인지 기존 url에서 '존재하지 않는 풀이'라고 렌더링할 것인지 생각
- 풀이 삭제 클릭 시, confirm 모달 띄우기
