### PR TITLE
풀이 삭제 기능 구현, 검색 리스트 아이템과 풀이 조회 페이지 CSS 개선

### DIFF
--- a/client/src/common/Card.js
+++ b/client/src/common/Card.js
@@ -9,6 +9,7 @@ const StyledCard = styled.div`
   cursor: pointer;
   &:hover {
     transform: translateY(-5%);
+    box-shadow: 0px 0px 1px 1px #9bc9b1;
   }
 `;
 

--- a/client/src/common/MarkDownPreview.js
+++ b/client/src/common/MarkDownPreview.js
@@ -14,7 +14,7 @@ const StyledPreview = styled(MarkdownPreview)`
   font-size: 2rem;
   width: 100%;
   ${(props) => props.styleWithWidth};
-  padding: var(--textarea-margin, 2%);
+  margin: var(--textarea-margin, 1.5rem);
   resize: none;
   border: 0px;
   min-height: 50rem;

--- a/client/src/contexts/ThemeContext.js
+++ b/client/src/contexts/ThemeContext.js
@@ -5,7 +5,7 @@ const ThemeContext = createContext();
 function ThemeContextProvider({ children }) {
   const theme = {
     main: '#9BC9B1',
-    background: '#353535',
+    background: '#222222',
     font: '#FFFFFF',
     content: '#FCFDFE'
   };

--- a/client/src/form/Solution.js
+++ b/client/src/form/Solution.js
@@ -31,8 +31,8 @@ export default function Solution({ content, setContent, toggle }) {
         />
       </div>
       <div style={{ fontSize: 'inherit', display: `${toggle ? 'block' : 'none'}` }}>
-        <div style={{ height: '4rem' }}>
-          <span style={{ opacity: 0.7 }}>{`프리뷰입니다 ᵔࡇᵔ`}</span>
+        <div style={{ height: '3.5rem' }}>
+          <span style={{ fontSize: '2rem', opacity: 0.7 }}>{`프리뷰입니다 ᵔࡇᵔ`}</span>
         </div>
         <MarkDownPreview source={content} />
       </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -18,7 +18,7 @@ code {
 
 input {
   color: white;
-  background-color: #353535;
+  background-color: #222222;
 }
 
 a {

--- a/client/src/page/EditPost.js
+++ b/client/src/page/EditPost.js
@@ -15,24 +15,16 @@ export default function EditPost() {
   const theme = useContext(ThemeContext);
   const [isLoggedIn, _, userData] = useContext(UserContext);
   const [setMessage] = useContext(ModalContext);
-  const [post, setPost] = useState({
-    id: '',
-    title: '',
-    platform: '',
-    subtitle: '',
-    language: '',
-    content: '',
-    writerId: ''
-  });
+  const [post, setPost] = useState(null);
   const [error, setError] = useState(null);
   const [__, requestService] = useToken();
 
   useEffect(() => {
     if (!isLoggedIn) return;
     (async () => {
-      const post = await fetchSolution_GET(id);
+      const { post, liker } = await fetchSolution_GET(id);
       // 게시물 id에 따라 error page 렌더링
-      if (userData.userId !== post.writerId) {
+      if (userData.userId !== post?.writerId ?? null) {
         setError('접근할 수 없는 권한입니다!'); // redirect
         return;
       }
@@ -59,6 +51,8 @@ export default function EditPost() {
   );
 
   if (!id) return <Template>잘못된 접근입니다!!</Template>;
+
+  if (!post) return <Template>존재하지않는 게시물!!</Template>;
 
   if (error) return <Template>{error}</Template>;
 

--- a/client/src/page/ReadPost.js
+++ b/client/src/page/ReadPost.js
@@ -1,18 +1,18 @@
 import { useContext, useEffect, useState } from 'react';
 import Template from '../Template';
-import { MarkDownPreview } from '../common/MarkDownPreview';
 import { fetchLike_DELETE, fetchLike_POST, fetchPost_GET } from '../post/fetchApis';
 import { fetchSolution_DELETE } from '../form/fetchApis';
 import Tag from '../common/Tag';
 import { RiThumbUpFill, RiChat1Fill } from 'react-icons/ri';
-import ThemeContext from '../contexts/ThemeContext';
 import queryString from 'query-string';
 import { useLocation } from 'react-router-dom';
 import { useHistory } from 'react-router';
+import MarkdownPreview from '@uiw/react-markdown-preview';
 import styled, { keyframes } from 'styled-components';
+import ThemeContext from '../contexts/ThemeContext';
 import UserContext from '../contexts/UserContext';
-import useToken from '../hooks/useToken';
 import ModalContext from '../contexts/ModalContext';
+import useToken from '../hooks/useToken';
 import Link from '../common/Link';
 
 const ResponsiveImage = ({ src }) => (
@@ -67,6 +67,53 @@ const StyledMenu = styled.div`
     border: none;
   }
 `;
+
+const StyledPreviewWrapper = styled.div`
+  font-size: inherit;
+  display: flex;
+  flex-direction: row;
+  background-color: ${(props) => props.backgroundColor};
+  color: white;
+`;
+
+const StyledPreview = styled(MarkdownPreview)`
+  font-size: 2rem;
+  width: 100%;
+  ${(props) => props.styleWithWidth};
+  resize: none;
+  border: 0px;
+  overflow: auto;
+
+  & pre {
+    background-color: #f4f4f4;
+  }
+
+  & pre * {
+    background: transparent;
+  }
+
+  & code {
+    color: black;
+  }
+
+  & blockquote {
+    color: #d0d0d0;
+  }
+
+  & h1,
+  h2,
+  h3 {
+    border-bottom: none;
+  }
+`;
+
+const MarkDownPreview = ({ source }) => {
+  return (
+    <StyledPreviewWrapper>
+      <StyledPreview source={source} />
+    </StyledPreviewWrapper>
+  );
+};
 
 export default function Post() {
   const { id } = queryString.parse(useLocation().search);
@@ -124,12 +171,14 @@ export default function Post() {
   };
 
   const onClickDelete = () => {
-    alert('정말 삭제하시겠습니까?');
+    const confirm = window.confirm('정말 삭제하시겠습니까?');
     (async () => {
-      const res = await requestService(() => fetchSolution_DELETE(id));
       // replace?
-      alert('삭제 됐습니다.');
-      history.goBack();
+      if (confirm) {
+        const res = await requestService(() => fetchSolution_DELETE(id));
+        alert('삭제 됐습니다.');
+        history.goBack();
+      }
     })();
   };
 
@@ -140,57 +189,65 @@ export default function Post() {
 
   if (isLoading) return <div>로딩 중</div>;
 
-  console.log(post);
-
   if (post === null) return <Template>존재하지 않는 게시물!!!</Template>;
   const { title, platform, subtitle, language, content, writeDate, writerId } = post;
 
   return (
     <Template header>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 10
-        }}
-      >
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: '16px' }}>
-          <ResponsiveImage src={`/images/${platform}-symbol.png`} />
-          <h1>{title}</h1>
-          {language && (
-            <div>
-              <Tag label={language} />
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 30,
+            backgroundColor: theme.background,
+            width: 700,
+            borderRadius: 30,
+            padding: '5%'
+          }}
+        >
+          <div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: '16px' }}>
+              <ResponsiveImage src={`/images/${platform}-symbol.png`} />
+              <h1 style={{ padding: 0, margin: 5 }}>{title}</h1>
+              {language && (
+                <div>
+                  <Tag label={language} />
+                </div>
+              )}
             </div>
+            <div>{subtitle}</div>
+          </div>
+          {userData.userId === writerId && (
+            <StyledMenu underlineColor={theme.main}>
+              <Link to={`/edit?id=${post._id}`}>수정</Link>
+              <button type="button" onClick={onClickDelete}>
+                <span>삭제</span>
+              </button>
+            </StyledMenu>
           )}
-        </div>
-        {userData.userId === writerId && (
-          <StyledMenu underlineColor={theme.main}>
-            <Link to={`/edit?id=${post._id}`}>수정</Link>
-            <button type="button" onClick={onClickDelete}>
-              <span>삭제</span>
-            </button>
-          </StyledMenu>
-        )}
-        <div>{subtitle}</div>
-        <div>
-          {writerId} ・ {writeDate}
-        </div>
-        {/* user profile component */}
-        <MarkDownPreview source={content} />
-        <div style={{ fontSize: '2.5rem', position: 'relative' }}>
-          {' '}
-          {clickLike && (
-            <StyledThumbsUpText>
-              <RiThumbUpFill color={theme.main} /> 좋은 솔루션이에요
-            </StyledThumbsUpText>
-          )}
-          <RiThumbUpFill
-            onClick={onClickLike}
-            color={isLiker ? theme.main : 'white'}
-            style={{ cursor: 'pointer' }}
-          />{' '}
-          {likeCount}
-          <RiChat1Fill color={theme.main} /> 0{' '}
+          <div>
+            <div>
+              {writerId} ・ {writeDate}
+            </div>
+          </div>
+          {/* user profile component */}
+          <MarkDownPreview source={content} />
+          <div style={{ fontSize: '2.5rem', position: 'relative' }}>
+            {' '}
+            {clickLike && (
+              <StyledThumbsUpText>
+                <RiThumbUpFill color={theme.main} /> 좋은 솔루션이에요
+              </StyledThumbsUpText>
+            )}
+            <RiThumbUpFill
+              onClick={onClickLike}
+              color={isLiker ? theme.main : 'white'}
+              style={{ cursor: 'pointer' }}
+            />{' '}
+            {likeCount}
+            <RiChat1Fill color={theme.main} /> 0{' '}
+          </div>
         </div>
       </div>
     </Template>

--- a/client/src/post/Post.js
+++ b/client/src/post/Post.js
@@ -27,7 +27,7 @@ export default function Post({ post }) {
   const theme = useContext(ThemeContext);
 
   return (
-    <Card color={theme.content}>
+    <Card color="transparent">
       <StyledPost>
         <div style={{ width: '85%' }}>
           <div
@@ -36,19 +36,20 @@ export default function Post({ post }) {
               flexDirection: 'row',
               justifyContent: 'flex-start',
               gap: '0.5rem',
-              alignItems: 'center'
+              alignItems: 'center',
+              color: 'white'
             }}
           >
             <ResponsiveImage src={`/images/${platform}-symbol.png`} />
             <div>
-              <strong>{title}</strong>
+              <strong style={{ color: 'white' }}>{title}</strong>
             </div>
             {language && <Tag label={language} size="1.6" />}
           </div>
-          <div>
+          <div style={{ color: 'white' }}>
             <span>{subtitle}</span>
           </div>
-          <div>
+          <div style={{ color: 'white' }}>
             {writerId} ・ {writeDate}
           </div>
         </div>
@@ -65,7 +66,7 @@ export default function Post({ post }) {
           <div>
             <span style={{ color: 'grey' }}>좋은 솔루션이에요</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center' }}>
+          <div style={{ display: 'flex', alignItems: 'center', color: 'white' }}>
             <RiThumbUpFill color={theme.main} size="2rem" />
             <strong>{likeCount}</strong>
           </div>


### PR DESCRIPTION
### 😻  풀이 삭제

- [x] 삭제 시 다른 url로 리다이렉트 or '존재하지 않은 게시물' 렌더링
- 정상적으로 삭제 시 history를 사용해 이전에 방문한 url로 이동한다.
- 존재하지 않는 게시물의 url을 입력할 경우 존재하지 않는 게시물을 렌더링한다.
- [x] 삭제 버튼 클릭 시 confirm  모달
- window api에서 제공하는 **confirm**을 사용했다. 사용자가 확인을 입력하면 true, 취소를 누르면 false를 반환하는 객체이다.
- 🤔 현재 window api에서 제공하는 confirm으로 삭제 확인에 대한 입력을 받았는데, 내 서비스의 modal을 활용하는 방법없는지 고려해보려고 한다..

### 😻  풀이 조회 / 검색 리스트 아이템
- 최대한 서비스의 컨셉에 맞추기 위해 css를 일관되게 개선했다.
      - 👀 눈의 편안함을 위해 최대한 흰색 배경의 사용은 지양
- 사용자가 글을 읽기 편하게 풀이 조회 페이지의 폭을 좁혔다.
