### PR TITLE
개선이 필요한 작업 (completed 2 task )

### DIFF
--- a/client/src/Template.js
+++ b/client/src/Template.js
@@ -5,9 +5,10 @@ import Button from './common/Button';
 import StickyHeader from './common/StickyHeader';
 import ThemeContext from './contexts/ThemeContext';
 import UserContext from './contexts/UserContext';
-import { RiCloseFill } from 'react-icons/ri';
+import { RiCloseFill, RiPencilFill } from 'react-icons/ri';
 import { useHistory } from 'react-router';
 import { fetchRefreshToken_POST } from './api/kakaoApi';
+import Link from './common/Link';
 
 const StyledBody = styled.div`
   width: 100%;
@@ -118,11 +119,19 @@ export default function Template({ header, children }) {
                 }}
               />
             ) : (
-              <div>
-                {userData.userId}
+              <div style={{ display: 'flex', alignItems: 'center', fontSize: '2rem' }}>
+                {userData.userId}님, 안녕하세요!
+                <Button
+                  label="작성하기"
+                  color="transparent"
+                  size="small"
+                  onClick={() => {
+                    history.push('/write');
+                  }}
+                />
                 <Button
                   label="로그아웃"
-                  color={theme.main}
+                  color="transparent"
                   size="small"
                   onClick={() => {
                     try {

--- a/client/src/common/Form.js
+++ b/client/src/common/Form.js
@@ -85,10 +85,10 @@ const ResponsiveImage = ({ src }) => (
   </div>
 );
 
-export default function Form({ post, setPost, Button }) {
-  const { title, platform, subtitle, language, content } = post;
+export default function Form({ post, postTitle, setPost, setPostTitle, Button }) {
+  const { subtitle, language, content } = post;
+  const { title, platform } = postTitle;
   const [toggle, setToggle] = useState(0);
-  const togglerRef = useRef(null);
 
   const onClick = () => {
     setToggle(!toggle);
@@ -111,8 +111,8 @@ export default function Form({ post, setPost, Button }) {
       <div style={{ height: 50, fontSize: '1rem' }}>
         {!(title && platform) ? (
           <URLField
-            setPlatformAndTitle={(platform, title) => {
-              setPost({ ...post, platform, title });
+            setPostTitle={(platform, title) => {
+              setPostTitle({ platform, title });
             }}
           />
         ) : (
@@ -122,7 +122,7 @@ export default function Form({ post, setPost, Button }) {
             <h1
               style={{ cursor: 'pointer' }}
               onClick={() => {
-                setPost({ ...post, title: '', platform: '' });
+                setPostTitle({ platform: '', title: '' });
               }}
             >
               <RiCloseFill size="3rem" />

--- a/client/src/form/URLField.js
+++ b/client/src/form/URLField.js
@@ -8,7 +8,7 @@ import Platform from './Platform';
 // platform 클래스를 이용하는 client는 내부 타입에 대해서 알지않게함.
 // 새로운 플랫폼에 신경쓰지 않고 유연한 처리 가능해짐.
 
-export function URLField({ setPlatformAndTitle }) {
+export function URLField({ setPostTitle }) {
   const theme = useContext(ThemeContext);
   const alertRef = useRef(null);
   const hrRef = useRef(null);
@@ -47,7 +47,7 @@ export function URLField({ setPlatformAndTitle }) {
       if (!url) return;
       try {
         const [name, title] = await fetchPlatformAndTitle(url);
-        setPlatformAndTitle(name, title);
+        setPostTitle(name, title);
       } catch (error) {
         alertRef.current.style.opacity = 1;
         return;

--- a/client/src/page/EditPost.js
+++ b/client/src/page/EditPost.js
@@ -18,6 +18,7 @@ export default function EditPost() {
   const [isLoggedIn, _, userData] = useContext(UserContext);
   const [setMessage] = useContext(ModalContext);
   const [post, setPost] = useState(null);
+  const [postTitle, setPostTitle] = useState(null);
   const [error, setError] = useState(null);
   const [__, requestService] = useToken();
 
@@ -30,14 +31,16 @@ export default function EditPost() {
         setError('접근할 수 없는 권한입니다!'); // redirect
         return;
       }
-      setPost(post);
+      const { title, platform, subtitle, language, content } = post;
+      setPost({ subtitle, language, content });
+      setPostTitle({ title, platform });
     })();
   }, [userData, isLoggedIn]); // 필드 초기값 설정
 
   const onClick = () => {
     // 데이터 유효성 검사
     (async () => {
-      const res = await requestService(() => fetchSolution_PUT(id, post));
+      const res = await requestService(() => fetchSolution_PUT(id, { ...post, ...postTitle }));
       const json = await res.json();
       if (res.status === 201) {
         history.replace(`/post?id=${json.post._id}`);
@@ -61,8 +64,14 @@ export default function EditPost() {
   return (
     <>
       <Template>
-        {isLoggedIn ? (
-          <Form post={post} setPost={setPost} Button={EditButton} />
+        {isLoggedIn && post && postTitle ? (
+          <Form
+            post={post}
+            postTitle={postTitle}
+            setPost={setPost}
+            setPostTitle={setPostTitle}
+            Button={EditButton}
+          />
         ) : (
           '서비스를 이용하려면 alog 서비스에 가입해주세요!'
         )}

--- a/client/src/page/WritePost.js
+++ b/client/src/page/WritePost.js
@@ -14,7 +14,7 @@ export default function WritePost() {
   const history = useHistory();
   const [setMessage] = useContext(ModalContext);
   const [isLoggedIn] = useContext(UserContext);
-ㅎ  const [post, setPost] = useState({
+  const [post, setPost] = useState({
     subtitle: '',
     language: '',
     content: ''

--- a/client/src/page/WritePost.js
+++ b/client/src/page/WritePost.js
@@ -14,19 +14,21 @@ export default function WritePost() {
   const history = useHistory();
   const [setMessage] = useContext(ModalContext);
   const [isLoggedIn] = useContext(UserContext);
-  const [post, setPost] = useState({
-    title: '',
-    platform: '',
+ㅎ  const [post, setPost] = useState({
     subtitle: '',
     language: '',
     content: ''
+  });
+  const [postTitle, setPostTitle] = useState({
+    platform: '',
+    title: ''
   });
   const [_, requestService] = useToken();
 
   const onClick = () => {
     // 데이터 유효성 검사
     (async () => {
-      const res = await requestService(() => fetchSolution_POST(post));
+      const res = await requestService(() => fetchSolution_POST({ ...post, ...postTitle }));
       const json = await res.json();
       if (res.status === 201) {
         history.replace(`/post?id=${json.post._id}`);
@@ -43,7 +45,13 @@ export default function WritePost() {
   return (
     <Template>
       {isLoggedIn ? (
-        <Form post={post} setPost={setPost} Button={WriteButton} />
+        <Form
+          post={post}
+          postTitle={postTitle}
+          setPost={setPost}
+          setPostTitle={setPostTitle}
+          Button={WriteButton}
+        />
       ) : (
         '접근할 수 없는 권한입니다!!!'
       )}


### PR DESCRIPTION
## 작업 내용
- [x] stickt header에 풀이 작성 아이콘 추가 
- [x] platform, title 상태 값과 그외 상태값들 독립적으로 상태 업데이트

**👀 식별된 문제**  url 입력 후 비동기 작업(fetch)이 발생하는데, 동시에 다른 field에 값을 입력하면 입력한 값이 무시된다.

기존 title, platform의 상태 업데이트 코드는 아래와 같다.
```javascript
setPost({ ...post, platform, title  });
```
비동기 작업 후에 상태 업데이트를 한다.
title, platform 상태값을 업데이트 하면서 외의 필드 값들도 유지하기 위해 위처럼 post를 가져왔다.
post는 비동기 작업이 일어나기 전의 값이기 때문에, 작업 시작 ~ 작업 완료 사이에 일어난 상태 업데이트들은 무시됐다. (비동기 작업 전의 post 값을 가져오기 때문에)

**해결방안** 간단하게 비동기 작업이 필요한 상태들은 다른 상태들과는 독립적으로 업데이트 되게해서 식별된 문제를 해결했다.