### PR TITLE
Update http 응답 캐시 설정

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -22,6 +22,10 @@ app.use(cors({
 app.use(express.json());
 app.use(logger('dev'));
 // app.use(express.urlencoded({ extended: false }));
+app.use(function (req, res, next) {
+  res.set('Cache-control', 'must-revalidate, max-age=31536000')
+  next();
+})
 app.use('/posts', postsRouter);
 app.use('/post', postRouter);
 app.use('/languages', languageRouter);


### PR DESCRIPTION
## 💻 작업 내용
- [x] 문제 원인 식별
- [x] 문제 해결

## 👀  식별된 문제
클라이언트가 서버로 부터 응답을 받아올 때, 매번 새로운 http 요청을 날려서 응답이 지연됨.

## 🔑 해결방안
``` javascript
 app.use(function (req, res, next) {
  res.set('Cache-control', 'must-revalidate, max-age=31536000')
  next();
})
```
서버 단에서 caching을 제어해주는 Cache-control을 설정해주어 해결.


resolved #51