### PR TITLE
사용자 마이 홈 구현 (Client & Server)

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -10,6 +10,7 @@ import UserContext, { UserContextProvider } from './contexts/UserContext';
 import SignUp from './page/SignUp';
 import { useContext, useEffect } from 'react';
 import useToken from './hooks/useToken';
+import UserHome from './page/UserHome';
 
 const MyComponent = ({ children }) => {
   const [isLoggedIn, setIsLoggedIn, userData, setUserData] = useContext(UserContext);
@@ -44,12 +45,12 @@ export default function App() {
             <Router>
               <Switch>
                 <Route path="/" exact component={Home} />
+                <Route path="/home/:ownerId" exact component={UserHome} />
                 <Route path="/write" exact component={WritePost} />
                 <Route path="/edit" exact component={EditPost} />
                 <Route path="/post" exact component={ReadPost} />
                 <Route path="/signup" exact component={SignUp} />
                 <Route path="/*" exact component={Error} />
-                {/* edit/:postsId */}
               </Switch>
             </Router>
           </MyComponent>

--- a/client/src/Template.js
+++ b/client/src/Template.js
@@ -10,6 +10,7 @@ import { RiCloseFill } from 'react-icons/ri';
 import { kakao_RefreshAccessToken, kakao_Logout, kakao_GetLoginUrl } from './api/kakaoApi';
 import { useMediaQuery } from 'react-responsive';
 import { RiPencilFill, RiLoginCircleFill, RiLogoutCircleFill } from 'react-icons/ri';
+import Link from './common/Link';
 
 const StyledBody = styled.div`
   width: 100%;
@@ -20,7 +21,7 @@ const StyledBody = styled.div`
   }
   @media screen and (min-width: 600px) {
     & > * {
-      padding: 10vh 15vw !important;
+      padding: 10vh 18vw !important;
     }
   }
 `;
@@ -125,6 +126,7 @@ export default function Template({ header, children }) {
               />
             ) : (
               <div style={{ display: 'flex', alignItems: 'center', fontSize: '2rem' }}>
+                <Link to={`/home/${userData.userId}`}>🌞</Link>
                 <span style={{ padding: '0.5rem 1rem' }}>{userData.userId}님, 안녕하세요!</span>
                 <Button
                   label={isBigScreen ? '작성하기' : <RiPencilFill />}

--- a/client/src/api/userApi.js
+++ b/client/src/api/userApi.js
@@ -1,0 +1,15 @@
+const fetchUserInfo_GET = async (target, finder) => {
+  try {
+    const response = await fetch(`/api/user?target=${target}&finder=${finder}`);
+
+    const result = await response.json();
+
+    console.log(result);
+    return result;
+  } catch (err) {
+    console.log(err);
+    return;
+  }
+};
+
+export { fetchUserInfo_GET };

--- a/client/src/common/Link.js
+++ b/client/src/common/Link.js
@@ -1,23 +1,14 @@
 import styled from 'styled-components';
 import { Link as OldLink } from 'react-router-dom';
-import { useContext } from 'react';
-import ThemeContext from '../contexts/ThemeContext';
-
 const StyledText = styled.span`
   color: white;
   font-size: inherit;
-
-  & :hover {
-    text-decoration: underline ${(props) => props.underlineColor};
-  }
 `;
 
 export default function Link({ to, replace, children }) {
-  const theme = useContext(ThemeContext);
-
   return (
     <OldLink to={to} replace={replace}>
-      <StyledText underlineColor={theme.main}>{children}</StyledText>
+      <StyledText>{children}</StyledText>
     </OldLink>
   );
 }

--- a/client/src/hooks/useGetPost.js
+++ b/client/src/hooks/useGetPost.js
@@ -13,9 +13,9 @@ export default function useGetPost() {
   const [isLoading, setIsLoading] = useState(false);
 
   const updatePost = async (option) => {
-    console.log(option);
     // queryObject는 Home에서 전달
-    if (!option.keyword) {
+    console.log(option);
+    if (!option.keyword && !option.writerId) {
       setTotalCount(0);
       setPosts([]);
       return;
@@ -23,6 +23,7 @@ export default function useGetPost() {
 
     setIsLoading(true);
     const res = await fetchPosts_GET(option);
+    console.log(res);
     setTotalCount(res.totalCount);
     setLeftCount(res.leftCount);
 

--- a/client/src/page/ReadPost.js
+++ b/client/src/page/ReadPost.js
@@ -239,14 +239,16 @@ export default function Post() {
               )}
               <div>
                 <div>
-                  {writerId} ・ {writeDate}
+                  <Link to={`/home/${writerId}`}>
+                    <strong>{writerId}</strong>
+                  </Link>
+                  ・ {writeDate}
                 </div>
               </div>
               <div style={{ width: '100%', height: 1, backgroundColor: 'grey' }} />
               {/* user profile component */}
               <MarkDownPreview source={content} />
               <div style={{ fontSize: '2.5rem', position: 'relative' }}>
-                {' '}
                 {clickLike && (
                   <StyledThumbsUpText>
                     <RiThumbUpFill color={theme.main} /> 좋은 솔루션이에요

--- a/client/src/page/UserHome.js
+++ b/client/src/page/UserHome.js
@@ -1,0 +1,65 @@
+import { useContext, useEffect, useRef, useState } from 'react';
+import { fetchUserInfo_GET } from '../api/userApi';
+import UserContext from '../contexts/UserContext';
+import useGetPost from '../hooks/useGetPost';
+import useIntersectionObserver from '../hooks/useIntersectionObserver';
+import PostList from '../post/PostList';
+import Template from '../Template';
+
+export default function UserHome({ match }) {
+  const { ownerId } = match.params;
+  const [createObserver, registerTargets] = useIntersectionObserver();
+  const [posts, totalCount, leftCount, isLoading, updatePost] = useGetPost();
+  const postListRef = useRef(null);
+  const [description, setDescription] = useState('');
+  const [_, __, userData] = useContext(UserContext);
+
+  const size = 3;
+
+  const handleIntersect = async () => {
+    if (leftCount === 0) return;
+    updatePost({
+      size,
+      cursor: posts[posts.length - 1]._id,
+      writerId: ownerId
+    });
+  };
+
+  useEffect(() => {
+    (async () => {
+      // 유효한 사용자 페이지라고 가정, 무효한 사용자라면 404 렌더링
+      const { _, description } = await fetchUserInfo_GET(ownerId, userData?.userId ?? '');
+      console.log(description);
+      setDescription(description);
+      updatePost({ size, writerId: ownerId });
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (posts.length === 0) return;
+    const postItems = postListRef.current.children;
+    const targetElement = postItems[postItems.length - 1];
+
+    createObserver(handleIntersect);
+    registerTargets([targetElement]);
+  }, [posts]);
+
+  return (
+    <Template header>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 30,
+          fontSize: '3rem'
+        }}
+      >
+        <div style={{ margin: '80px 0' }}>
+          🌞 <strong>{ownerId}</strong> {description}
+        </div>
+        <div style={{ width: '100%', backgroundColor: 'grey', height: '1px' }}></div>
+        <PostList postListRef={postListRef} posts={posts} />
+      </div>
+    </Template>
+  );
+}

--- a/server/app.js
+++ b/server/app.js
@@ -4,6 +4,7 @@ dotenv.config();
 import express from 'express';
 import cors from 'cors';
 import logger from 'morgan';
+import userRouter from './routes/user.js';
 import postsRouter from './routes/posts.js';
 import postRouter from './routes/post.js';
 import languageRouter from './routes/language.js';
@@ -26,6 +27,7 @@ app.use(function (req, res, next) {
   res.set('Cache-control', 'must-revalidate, max-age=31536000')
   next();
 })
+app.use('/user', userRouter);
 app.use('/posts', postsRouter);
 app.use('/post', postRouter);
 app.use('/languages', languageRouter);

--- a/server/queries/post.js
+++ b/server/queries/post.js
@@ -49,12 +49,16 @@ const findPosts = async (keyword, language, cursor, size, writerId) => {
 
    // 데이터를 페이징 하며 가져오도록 추후 변경 (무한 스크롤 구현 기능 시)
   try {
-    if (!keyword) return [];
-    const filter = { title: { $regex: '.*' + keyword + '.*' }};
+    const filter = {};
+    if (keyword) {
+      keyword = keyword.replace(/\+/g, '\\+');
+      filter.title = { $regex: '.*' + keyword + '.*' };
+    } 
     if (cursor) filter._id = { $lt: cursor };
     if (language) filter.language = { $in: language };
     if (writerId) filter.writerId = writerId;
 
+    console.log(filter);
     const doc = await Post.find(filter).sort('field -_id').limit(parseInt(size)).exec();
     return doc;
   } catch (err) {
@@ -67,8 +71,11 @@ const findPosts = async (keyword, language, cursor, size, writerId) => {
  */
 const countPosts = async (keyword, language, writerId) => {
  try {
-  if (!keyword) return [];
-  const filter = { title: { $regex: '.*' + keyword + '.*' }};
+  const filter = {};
+  if (keyword) {
+    keyword = keyword.replace(/\+/g, '\\+');
+    filter.title = { $regex: '.*' + keyword + '.*' };
+  } 
   if (language) filter.language = { $in: language };
   if (writerId) filter.writerId = writerId;
 
@@ -86,8 +93,11 @@ const countPosts = async (keyword, language, writerId) => {
  */
  const leftPosts = async (keyword, language, cursor, writerId) => { 
   try {
-    if (!keyword) return [];
-    const filter = { title: { $regex: '.*' + keyword + '.*' }};
+    const filter = {};
+    if (keyword) {
+      keyword = keyword.replace(/\+/g, '\\+');
+      filter.title = { $regex: '.*' + keyword + '.*' };
+    } 
     if (cursor) filter._id = { $lt: cursor };
     if (language) filter.language = { $in: language };
     if (writerId) filter.writerId = writerId;

--- a/server/routes/posts.js
+++ b/server/routes/posts.js
@@ -16,11 +16,7 @@ router.get('/', async (req, res) => {
 // writerId, language, cursor는 undefined로 전달될 수도 있는 값.
 // 클라이언트 단에서 부터 요청 전 이를 처리해주도록 해야한다.
 router.get('/search', async (req, res) => {
-  // keyword uri encode 하개ㅣ
-
   let { keyword, languages, cursor, size, writerId } = req.query;
-  keyword = keyword.replace(/\+/g, '\\+');
-
   const totalCount = await countPosts(keyword, languages ? languages.split(',') : null, writerId);
   const leftCount = await leftPosts(keyword, languages ? languages.split(',') : null, cursor, writerId);
   let posts = await findPosts(keyword, languages ? languages.split(',') : null, cursor, size, writerId);

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import { findUser } from '../queries/user.js';
+const router = express.Router();
+
+router.get('/', async (req, res) => {
+  const { target, finder } = req.query;
+  const user = await findUser({ userId: target });
+
+  if (!user) {
+    res.status(404).json('no data');
+    return;
+  }
+
+
+  if (target !== finder) {
+    res.status(200).json({ userId: user.userId, description: user.description });
+  } else {
+    res.status(200).json(user);
+  }
+});
+
+export default router;


### PR DESCRIPTION
Client
- 마이 홈 페이지 url ```/home/:userId```

Server
- 기존  find post 쿼리는 keyword가 없으면 무조건 빈 배열을 반환
=> 마이 홈에서는 유저 아이디로만 포스트 조회 가능함
=> 아래 처럼 **filter**를 수정하였음 

``` javascript
const filter = {};
    if (keyword) {
      keyword = keyword.replace(/\+/g, '\\+');
      filter.title = { $regex: '.*' + keyword + '.*' };
    } 
    if (cursor) filter._id = { $lt: cursor };
    if (language) filter.language = { $in: language };
    if (writerId) filter.writerId = writerId;
```
- 사용자 데이터 처리 (등/수/삭/조)는 새로 만든 user route에서 처리