### PR TITLE
Fix 캐싱 버그

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -24,11 +24,6 @@ app.use(cors({
 app.use(express.json());
 app.use(logger('dev'));
 // app.use(express.urlencoded({ extended: false }));
-app.use(function (req, res, next) {
-  res.set('Cache-control', 'must-revalidate, max-age=31536000')
-  next();
-})
-app.use('/images/profile', express.static('images/profile')); // 프로필 사진 요청
 app.use('/user', userRouter);
 app.use('/posts', postsRouter);
 app.use('/post', postRouter);
@@ -36,6 +31,12 @@ app.use('/languages', languageRouter);
 app.use('/like', likeRouter);
 app.use('/auth', authRouter);
 app.use('/kakaoAuth', kakaoAuthRouter);
+
+app.use(function (req, res, next) {
+  res.set('Cache-control', 'max-age=31536000')
+  next();
+})
+app.use('/images/profile', express.static('images/profile')); // 프로필 사진 요청
 
 app.use((req, res, next) => { // 매핑되는 경로 없을 때
   res.status(404).send('not found page');

--- a/server/routes/post.js
+++ b/server/routes/post.js
@@ -33,7 +33,7 @@ router.use((req, res, next) => {
     const { userId } = jwt.verify(accessToken, process.env.ACCESS_SECRET_KEY);
     req.userId = userId;
     next();
-  } catch (error) {
+  } catch ({ name }) {
     if (name === 'TokenExpiredError') {
       res.status(401).json({ error: 'expired token' });
       return;


### PR DESCRIPTION
## 식별된 버그
- 솔루션 좋아요 반영 X
- 토큰 검증 error 값만 반환
- 글 등록 정상적으로 작동 X

## 근본적인 문제
- Cache-Control을 잘못쓰고 있었음.
- 모든 요청을 영구적으로 캐싱하고 있어 업데이트 된 값이 반영되지 않아 요청이 필요한 기능 곳곳에 버그를 야기했음.

아래는 잘못된 코드이다.
``` javascript
app.use(function (req, res, next) {
  res.set('Cache-control', 'must-revalidate, max-age=31536000')
  next();
})
// ... routers
```
이렇게 설정하면 설정해둔 기간동안은 데이터가 변경이 되더라도 브라우저 캐시에서 데이터를 가져온다.
따라서 업데이트 되었더라도, 기존 캐싱된 데이터를 가져오니 업데이트 사항이 반영되지 않았던 것이다.

브라우저에서는 기본적으로 get 요청에 한해서, no-cache를 설정했음을 확인했다.
**no-cache? 캐시하지만 재검증** -> 재검증해서 그대로면 캐싱된 데이터를, 변경사항있으면 api 서버에서 새로운 데이터를 캐싱한다.

아래처럼 이미지 파일만 캐싱하도록 설정했다.
``` javascript
// ... routers
app.use(function (req, res, next) {
  res.set('Cache-control', 'max-age=31536000')
  next();
})
app.use('/images/profile', express.static('images/profile'));
```