### PR TITLE
Fix 식별된 버그

### DIFF
--- a/client/src/page/UserHome.js
+++ b/client/src/page/UserHome.js
@@ -9,8 +9,8 @@ import useIntersectionObserver from '../hooks/useIntersectionObserver';
 import PostList from '../post/PostList';
 import Template from '../Template';
 
-export default function UserHome({ match }) {
-  const { ownerId } = match.params;
+export default function UserHome(props) {
+  const { ownerId } = props.match.params;
   const [createObserver, registerTargets] = useIntersectionObserver();
   const [posts, totalCount, leftCount, isLoading, updatePost] = useGetPost();
   const postListRef = useRef(null);
@@ -39,7 +39,7 @@ export default function UserHome({ match }) {
       updatePost({ size, writerId: ownerId });
       setLoading(false);
     })();
-  }, []);
+  }, [props]);
 
   useEffect(() => {
     if (posts.length === 0) return;

--- a/client/src/page/WritePost.js
+++ b/client/src/page/WritePost.js
@@ -24,12 +24,16 @@ export default function WritePost() {
     title: ''
   });
   const [_, requestService] = useToken();
+  const [isFetching, setIsFetching] = useState(false);
 
   const onClick = () => {
     // 데이터 유효성 검사
     (async () => {
+      setIsFetching(true);
       const res = await requestService(() => fetchSolution_POST({ ...post, ...postTitle }));
       const json = await res.json();
+      setIsFetching(false);
+
       if (res.status === 201) {
         history.replace(`/post?id=${json.post._id}`);
         return;
@@ -39,7 +43,7 @@ export default function WritePost() {
   };
 
   const WriteButton = () => (
-    <Button label="작성" color={theme.main} size="small" onClick={onClick} />
+    <Button label="작성" color={theme.main} size="small" onClick={onClick} disabled={isFetching} />
   );
 
   return (


### PR DESCRIPTION
userHome 연속 렌더링 시 데이터를 새로 가져오지 않음
- url 변경에 따라 새로 마운트 되는 것을 기대했지만, 실제로는 props가 변경되어 컴포넌트가 리렌더링을 함.
->  props가 변경될 시 ownerId 에 대응하는 새로운 데이터를 받아오도록 수정

솔루션 등록 버튼 연속 클릭 시 동일한 솔루션 연속 생성
-> 통신상태를 확인하는 **isFetching** 상태 추가. 이를 통해 버튼을 제어함.
```javascript
 <Button ... disabled={isFetching} />
```
  
