### PR TITLE
Fix CRA 버전업에 따른 Buffer 모듈 사용 오류

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^11.1.0",
         "@testing-library/user-event": "^12.1.10",
         "@uiw/react-markdown-preview": "^4.1.14",
+        "jwt-decode": "^3.1.2",
         "query-string": "^4.3.4",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
@@ -5592,6 +5593,14 @@
       "integrity": "sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/Buffer": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/Buffer/-/Buffer-0.0.0.tgz",
+      "integrity": "sha512-+zdncl8lI5TCkARStn9F1BwcuJYofYmD0oEHe5FNfCvGfeDJwf6+dSikCdQN6BMXXmHMhNNUagBN367WST1AIQ==",
+      "engines": {
+        "node": ">= 0.2.0"
       }
     },
     "node_modules/buffer-from": {
@@ -11925,6 +11934,11 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -17670,16 +17684,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
-      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "@testing-library/react": "^11.1.0",
     "@testing-library/user-event": "^12.1.10",
     "@uiw/react-markdown-preview": "^4.1.14",
+    "jwt-decode": "^3.1.2",
     "query-string": "^4.3.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -11,6 +11,7 @@ import SignUp from './page/SignUp';
 import { useContext, useEffect } from 'react';
 import useToken from './hooks/useToken';
 import UserHome from './page/UserHome';
+import jwtDecode from 'jwt-decode';
 
 const MyComponent = ({ children }) => {
   const [isLoggedIn, setIsLoggedIn, userData, setUserData] = useContext(UserContext);
@@ -24,7 +25,7 @@ const MyComponent = ({ children }) => {
         if (!accessToken) return;
         // authorization 호출을 통해 토큰이 인증된 상태이며 유효한 access_token을 가지고 있음.
         // 유저 정보 업데이트를 위해 client 단에서 token을 읽어내 유저 정보를 얻는다
-        const { userId } = JSON.parse(Buffer.from(accessToken.split('.')[1], 'base64').toString());
+        const { userId } = jwtDecode(accessToken);
         setUserData({ ...userData, userId: userId });
         setIsLoggedIn(true);
       } catch (error) {


### PR DESCRIPTION
# 작업 설명
CRA 버전업에 따른 Buffer 모듈 사용 오류

# 작업 내용

``` javascript
const MyComponent = ({ children }) => {
  const [isLoggedIn, setIsLoggedIn, userData, setUserData] = useContext(UserContext);
  const [getValidToken] = useToken();

  useEffect(() => {
    (async () => {
      try {
        // ...
        const { userId } = JSON.parse(Buffer.from(accessToken.split('.')[1], 'base64').toString());
       // ....
      } catch (error) {
        console.log(error);
      }
    })();
  }, []);

  return <>{children}</>;
};
```

상위 코드 실행 시, 파싱과정에서 다음과 같은 에러 발생 `ReferenceError: Buffer is not defined at App.js:27:1`
cra v4 -> v5 버전변경에 따라 webpack버전이 v5로 업그레이드 되면서 기존에는 제공했던 Buffer 모듈이 제공되지않음. ([CRA 공식 changelog](https://github.com/facebook/create-react-app/blob/main/CHANGELOG.md))
이를 사용하기위해 모듈 설치, 폴리필 설치과정이 필요했고 jwt 토큰을 decode할 수 있는 전용 모듈을 찾아 이를 적용해서 해결함


