### PR TITLE
페이지 Lazy 로딩을 통한 성능 향상

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -19,4 +19,6 @@ sketch
 
 README.md
 
+build
+
 # End of https://www.toptal.com/developers/gitignore/api/reac

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -1,6 +1,4 @@
 import Home from './page/Home';
-import WritePost from './page/WritePost';
-import EditPost from './page/EditPost';
 import ReadPost from './page/ReadPost';
 import Error from './page/Error';
 import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
@@ -8,10 +6,13 @@ import { ThemeContextProvider } from './contexts/ThemeContext';
 import { ModalContextProvider } from './contexts/ModalContext';
 import UserContext, { UserContextProvider } from './contexts/UserContext';
 import SignUp from './page/SignUp';
-import { useContext, useEffect } from 'react';
+import { Suspense, lazy, useContext, useEffect } from 'react';
 import useToken from './hooks/useToken';
 import UserHome from './page/UserHome';
 import jwtDecode from 'jwt-decode';
+import Loading from './common/Loading';
+const WritePost = lazy(() => import('./page/WritePost'));
+const EditPost = lazy(() => import('./page/EditPost'));
 
 const MyComponent = ({ children }) => {
   const [isLoggedIn, setIsLoggedIn, userData, setUserData] = useContext(UserContext);
@@ -42,19 +43,35 @@ export default function App() {
     <ThemeContextProvider>
       <ModalContextProvider>
         <UserContextProvider>
-          <MyComponent>
-            <Router>
-              <Switch>
-                <Route path="/" exact component={Home} />
-                <Route path="/home/:ownerId" exact component={UserHome} />
-                <Route path="/write" exact component={WritePost} />
-                <Route path="/edit" exact component={EditPost} />
-                <Route path="/post" exact component={ReadPost} />
-                <Route path="/signup" exact component={SignUp} />
-                <Route path="/*" exact component={Error} />
-              </Switch>
-            </Router>
-          </MyComponent>
+          <Suspense
+            fallback={
+              <div
+                style={{
+                  height: '80vh',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  justifyContent: 'center',
+                  alignItems: 'center'
+                }}
+              >
+                <Loading />
+              </div>
+            }
+          >
+            <MyComponent>
+              <Router>
+                <Switch>
+                  <Route path="/" exact component={Home} />
+                  <Route path="/home/:ownerId" exact component={UserHome} />
+                  <Route path="/write" exact component={WritePost} />
+                  <Route path="/edit" exact component={EditPost} />
+                  <Route path="/post" exact component={ReadPost} />
+                  <Route path="/signup" exact component={SignUp} />
+                  <Route path="/*" exact component={Error} />
+                </Switch>
+              </Router>
+            </MyComponent>
+          </Suspense>
         </UserContextProvider>
       </ModalContextProvider>
     </ThemeContextProvider>

--- a/client/src/common/Loading.js
+++ b/client/src/common/Loading.js
@@ -3,15 +3,15 @@ import styled, { keyframes } from 'styled-components';
 import ThemeContext from '../contexts/ThemeContext';
 
 const loading = keyframes`
-  0 {
-    transform: translateY(0);
-  }
-  50% {
-    transform: translateY(15px);
-  }
-  100% {
-    transform: translateY(0);
-  }
+0% {
+  transform: translateY(0);
+}
+50% {
+  transform: translateY(15px);
+}
+100% {
+  transform: translateY(0);
+} 
 `;
 
 const StyledLoading = styled.div`

--- a/client/src/contexts/UserContext.js
+++ b/client/src/contexts/UserContext.js
@@ -1,16 +1,26 @@
 import { createContext, useState } from 'react';
 const UserContext = createContext();
 
+// 성능 테스트를 위한 초기 상태 설정
+const isTestEnv = process.env.REACT_APP_ENV === 'test';
+
+const initIsLoggedIn = isTestEnv ? true : false;
+const initUserData = {
+  userId: null,
+  profile_fileName: window.localStorage.getItem('profile_fileName') || null,
+  api_accessToken: window.localStorage.getItem('api_accessToken') || null,
+  api_refreshToken: window.localStorage.getItem('api_refreshToken') || null,
+  accessToken: window.localStorage.getItem('accessToken') || null,
+  refreshToken: window.localStorage.getItem('refreshToken') || null
+};
+
+if (isTestEnv) {
+  initUserData.userId = 'ALOG 테스터';
+}
+
 function UserContextProvider({ children }) {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
-  const [userData, setUserData] = useState({
-    userId: null,
-    profile_fileName: window.localStorage.getItem('profile_fileName') || null,
-    api_accessToken: window.localStorage.getItem('api_accessToken') || null,
-    api_refreshToken: window.localStorage.getItem('api_refreshToken') || null,
-    accessToken: window.localStorage.getItem('accessToken') || null,
-    refreshToken: window.localStorage.getItem('refreshToken') || null
-  });
+  const [isLoggedIn, setIsLoggedIn] = useState(initIsLoggedIn);
+  const [userData, setUserData] = useState(initUserData);
 
   return (
     <UserContext.Provider value={[isLoggedIn, setIsLoggedIn, userData, setUserData]}>


### PR DESCRIPTION
# 작업 설명
지연로딩 적용을 통한 앱 로딩 속도 개선

# 작업 내용
- React의 Lazy API를 통해 `WritePost`, `EditPost` 페이지 단위의 컴포넌트 지연 로딩
  - ⚠️ Suspense로 전체 앱을 감싸준 상태이기 때문에 하위 컴포넌트에서 부분적으로 로딩 처리가 필요한 부분을 꼼꼼히 처리해줘야함.
  => 현재 상황에서는 Data Fetching 라이브러리의 사용이 없기도 하고, loading렌더링이 필요한 기능을 모두 처리하고 있어 문제없음.
  - 사용자 관심사를 기준으로 두어 글 작성자, 글 독자를 구분했고 따라서 글 수정 및 등록 컴포넌트에만 지연로딩을 적용함
  - 작은 컴포넌트에 적용하면 오히려 HTTP 통신 비용 때문에 성능이 저하될 수 있을 것이라고 생각해 페이지 단위로 적용

- 성능 테스트를 위한 강제 로그인 기능 추가
  - `REACT_APP_ENV` 환경 변수가 test로 설정돼있다면, 강제로그인을 함으로써 PageSights와 같은 성능 측정 도구를 통해 인증에 성공했을 때의 화면을 테스트하고자함.
  - ⚠️ 실제 배포 서비스에 대한 성능 테스트시에 해당 환경 변수를  `test`를 설정하고, 완료되면 반드시 `production`값으로 설정해야함.
