### PR TITLE
메인 페이지 리팩토링 - Home 컴포넌트 관심사분리

### DIFF
--- a/client/src/hooks/useGetPost.ts
+++ b/client/src/hooks/useGetPost.ts
@@ -7,29 +7,13 @@ import { useRef, useState } from 'react';
 import { fetchPosts_GET } from '../post/fetchApis';
 import { Option } from 'types/api';
 import { IPost } from 'types/post';
-import { safelyCheckPosts } from 'api/helper';
+import { PostStorage } from 'storage/SessionStorage';
 
-interface IData {
+export interface IData {
   posts: IPost[];
   leftCount: number;
   totalCount: number;
 }
-
-const PostStorage = {
-  get: (key: string) => {
-    const value = window.sessionStorage.getItem(key);
-    if (!value) {
-      return null;
-    }
-    const data = JSON.parse(value);
-    // TODO: safelyCheckPosts 공통 함수로 뺄지 여부
-    safelyCheckPosts(data);
-    return data;
-  },
-  set: (key: string, value: IData) => {
-    window.sessionStorage.setItem(key, JSON.stringify(value));
-  }
-};
 
 export default function useGetPost() {
   const [data, setData] = useState<IData>(() => {

--- a/client/src/page/Home.tsx
+++ b/client/src/page/Home.tsx
@@ -162,7 +162,7 @@ export default function Home() {
 
       languagesData = fetchedLanguages;
 
-      LanguageStorage.set('languages', languagesData);
+      LanguageStorage.set(languagesData);
     }
 
     // 첫 로딩, pop state

--- a/client/src/page/Home.tsx
+++ b/client/src/page/Home.tsx
@@ -1,7 +1,6 @@
 import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import useDebounce from '../hooks/useDebounce';
 import useGetPost from '../hooks/useGetPost';
-import useIntersectionObserver from '../hooks/useIntersectionObserver';
 import { fetchLanguages_GET } from '../post/fetchApis';
 import PostList from '../post/PostList';
 import FilterList from '../post/FilterList';
@@ -73,13 +72,10 @@ export default function Home() {
     return languages.map(({ name }) => filteredLanguages.includes(name));
   });
 
-  const postListRef = useRef<HTMLDivElement | null>(null);
-  const { createObserver, registerTargets } = useIntersectionObserver();
   const [isLanguageLoading, setIsLanguageLoading] = useState(false);
 
   const handleIntersect = () => {
     if (leftCount === 0) return;
-
     updatePost({
       keyword,
       languages: languages.filter((_, index) => isSelected[index]).map(({ name }) => name),
@@ -228,19 +224,6 @@ export default function Home() {
     };
   }, []);
 
-  useEffect(() => {
-    if (posts.length === 0) return;
-    if (postListRef.current === null) {
-      return;
-    }
-    const lastPost = postListRef.current.lastElementChild;
-    if (!(lastPost instanceof HTMLElement)) {
-      return;
-    }
-    createObserver(handleIntersect);
-    registerTargets([lastPost]);
-  }, [posts]);
-
   const location = useLocation();
   const mount = useRef(false);
 
@@ -308,41 +291,7 @@ export default function Home() {
             Component={<div style={{ width: '20rem', height: '5rem', borderRadius: '2rem' }} />}
           />
         )}
-        <PostList postListRef={postListRef} posts={posts} />
-        {isLoading && (
-          <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 50 }}>
-            {new Array(3).fill(null).map((_, index) => (
-              <div
-                key={index}
-                style={{
-                  width: '100%',
-                  display: 'flex',
-                  flexDirection: 'row',
-                  gap: '0.5rem',
-                  justifyContent: 'space-between'
-                }}
-              >
-                <div
-                  style={{ display: 'flex', flexDirection: 'column', gap: '1rem', width: '75%' }}
-                >
-                  <Skeleton
-                    Component={
-                      <div style={{ width: '40%', height: '5rem', borderRadius: '2rem' }} />
-                    }
-                  />
-                  <Skeleton
-                    Component={
-                      <div style={{ width: '60%', height: '5rem', borderRadius: '2rem' }} />
-                    }
-                  />
-                </div>
-                <div style={{ width: '15%' }}>
-                  <Skeleton Component={<div style={{ height: '10rem', borderRadius: '2rem' }} />} />
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+        <PostList posts={posts} handleIntersect={handleIntersect} isLoading={isLoading} />
       </div>
     </Template>
   );

--- a/client/src/page/UserHome.js
+++ b/client/src/page/UserHome.js
@@ -23,13 +23,11 @@ const ProfileSkeleton = ({ ownerId }) => (
 
 export default function UserHome(props) {
   const { ownerId } = props.match.params;
-  const { createObserver, registerTargets } = useIntersectionObserver();
   const {
     data: { posts, totalCount, leftCount },
     isLoading,
     updatePost
   } = useGetPost();
-  const postListRef = useRef(null);
   const [ownerData, setOwnerData] = useState('');
   const { description, profilePath } = ownerData;
   const [_, __, userData] = useContext(UserContext);
@@ -56,15 +54,6 @@ export default function UserHome(props) {
       setLoading(false);
     })();
   }, [props]);
-
-  useEffect(() => {
-    if (posts.length === 0) return;
-    const postItems = postListRef.current.children;
-    const targetElement = postItems[postItems.length - 1];
-
-    createObserver(handleIntersect);
-    registerTargets([targetElement]);
-  }, [posts]);
 
   return (
     <Template header>
@@ -116,41 +105,7 @@ export default function UserHome(props) {
             작성된 솔루션이 없어요.
           </div>
         )}
-        <PostList postListRef={postListRef} posts={posts} />
-        {isLoading && (
-          <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 50 }}>
-            {new Array(3).fill(null).map((e, index) => (
-              <div
-                key={index}
-                style={{
-                  width: '100%',
-                  display: 'flex',
-                  flexDirection: 'row',
-                  gap: '0.5rem',
-                  justifyContent: 'space-between'
-                }}
-              >
-                <div
-                  style={{ display: 'flex', flexDirection: 'column', gap: '1rem', width: '75%' }}
-                >
-                  <Skeleton
-                    Component={
-                      <div style={{ width: '40%', height: '5rem', borderRadius: '2rem' }} />
-                    }
-                  />
-                  <Skeleton
-                    Component={
-                      <div style={{ width: '60%', height: '5rem', borderRadius: '2rem' }} />
-                    }
-                  />
-                </div>
-                <div style={{ width: '15%' }}>
-                  <Skeleton Component={<div style={{ height: '10rem', borderRadius: '2rem' }} />} />
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
+        <PostList posts={posts} isLoading={isLoading} handleIntersect={handleIntersect} />
       </div>
     </Template>
   );

--- a/client/src/post/PostList.tsx
+++ b/client/src/post/PostList.tsx
@@ -1,6 +1,9 @@
 import { IPost } from 'types/post';
 import Post from './Post';
 import styled from 'styled-components';
+import { useEffect, useRef } from 'react';
+import useIntersectionObserver from 'hooks/useIntersectionObserver';
+import Skeleton from 'common/Skeleton';
 
 const StyledPostList = styled.div`
   display: flex;
@@ -9,16 +12,63 @@ const StyledPostList = styled.div`
 `;
 
 interface PostListProps {
-  postListRef: React.RefObject<HTMLDivElement>;
+  isLoading: boolean;
   posts: IPost[];
+  handleIntersect: () => void;
 }
 
-export default function PostList({ postListRef, posts }: PostListProps) {
+export default function PostList({ isLoading, posts, handleIntersect }: PostListProps) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const { createObserver, registerTargets } = useIntersectionObserver();
+
+  useEffect(() => {
+    if (posts.length === 0) return;
+    if (ref.current === null) {
+      return;
+    }
+    const lastPost = ref.current.lastElementChild;
+    if (!(lastPost instanceof HTMLElement)) {
+      return;
+    }
+    createObserver(handleIntersect);
+    registerTargets([lastPost]);
+  }, [posts]);
+
   return (
-    <StyledPostList ref={postListRef}>
-      {posts.map((post) => (
-        <Post key={post._id} post={post} />
-      ))}
-    </StyledPostList>
+    <>
+      <StyledPostList ref={ref}>
+        {posts.map((post) => (
+          <Post key={post._id} post={post} />
+        ))}
+      </StyledPostList>
+      {isLoading && (
+        <div style={{ width: '100%', display: 'flex', flexDirection: 'column', gap: 50 }}>
+          {new Array(3).fill(null).map((_, index) => (
+            <div
+              key={index}
+              style={{
+                width: '100%',
+                display: 'flex',
+                flexDirection: 'row',
+                gap: '0.5rem',
+                justifyContent: 'space-between'
+              }}
+            >
+              <div style={{ display: 'flex', flexDirection: 'column', gap: '1rem', width: '75%' }}>
+                <Skeleton
+                  Component={<div style={{ width: '40%', height: '5rem', borderRadius: '2rem' }} />}
+                />
+                <Skeleton
+                  Component={<div style={{ width: '60%', height: '5rem', borderRadius: '2rem' }} />}
+                />
+              </div>
+              <div style={{ width: '15%' }}>
+                <Skeleton Component={<div style={{ height: '10rem', borderRadius: '2rem' }} />} />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
   );
 }

--- a/client/src/storage/LocalStorage.ts
+++ b/client/src/storage/LocalStorage.ts
@@ -1,6 +1,6 @@
-const Localstorage = window.localStorage;
+import { FILTER_LANGUAGES_KEY } from './constants';
 
-const FILTER_LANGUAGES_KEY = 'filter_languages';
+const Localstorage = window.localStorage;
 
 const saveFilteredLangauges = (languages: string[]) => {
   Localstorage.setItem(FILTER_LANGUAGES_KEY, JSON.stringify(languages));

--- a/client/src/storage/SessionStorage.ts
+++ b/client/src/storage/SessionStorage.ts
@@ -20,9 +20,10 @@ export const PostStorage = {
   }
 };
 
+const LanguageStorageKey = 'languages';
 export const LanguageStorage = {
-  get: (key = 'languages') => {
-    const value = sessionStorage.getItem(key);
+  get: () => {
+    const value = sessionStorage.getItem(LanguageStorageKey);
     if (!value) {
       return null;
     }
@@ -30,8 +31,8 @@ export const LanguageStorage = {
     safelyCheckLanguages(data);
     return data;
   },
-  set: (key: string, value: Language[]) => {
-    sessionStorage.setItem(key, JSON.stringify(value));
+  set: (value: Language[]) => {
+    sessionStorage.setItem(LanguageStorageKey, JSON.stringify(value));
   }
 };
 

--- a/client/src/storage/SessionStorage.ts
+++ b/client/src/storage/SessionStorage.ts
@@ -1,6 +1,7 @@
 import { Language } from 'types/api';
 import { safelyCheckPosts } from 'api/helper';
 import { IData } from 'hooks/useGetPost';
+import { LANGUAGE_STORAGE_KEY } from './constants';
 
 const { sessionStorage } = window;
 
@@ -20,10 +21,9 @@ export const PostStorage = {
   }
 };
 
-const LanguageStorageKey = 'languages';
 export const LanguageStorage = {
   get: () => {
-    const value = sessionStorage.getItem(LanguageStorageKey);
+    const value = sessionStorage.getItem(LANGUAGE_STORAGE_KEY);
     if (!value) {
       return null;
     }
@@ -32,7 +32,7 @@ export const LanguageStorage = {
     return data;
   },
   set: (value: Language[]) => {
-    sessionStorage.setItem(LanguageStorageKey, JSON.stringify(value));
+    sessionStorage.setItem(LANGUAGE_STORAGE_KEY, JSON.stringify(value));
   }
 };
 

--- a/client/src/storage/SessionStorage.ts
+++ b/client/src/storage/SessionStorage.ts
@@ -1,6 +1,24 @@
 import { Language } from 'types/api';
+import { safelyCheckPosts } from 'api/helper';
+import { IData } from 'hooks/useGetPost';
 
 const { sessionStorage } = window;
+
+export const PostStorage = {
+  get: (key: string) => {
+    const value = sessionStorage.getItem(key);
+    if (!value) {
+      return null;
+    }
+    const data = JSON.parse(value);
+    // TODO: safelyCheckPosts 공통 함수로 뺄지 여부
+    safelyCheckPosts(data);
+    return data;
+  },
+  set: (key: string, value: IData) => {
+    sessionStorage.setItem(key, JSON.stringify(value));
+  }
+};
 
 export const LanguageStorage = {
   get: (key = 'languages') => {

--- a/client/src/storage/constants.ts
+++ b/client/src/storage/constants.ts
@@ -1,0 +1,2 @@
+export const LANGUAGE_STORAGE_KEY = 'languages';
+export const FILTER_LANGUAGES_KEY = 'filter_languages';


### PR DESCRIPTION
# 작업 설명
유지보수성 향상을 위한 메인 페이지 리팩토링

# 작업 내용
**관심사 분리**
- 무한 스크롤 기능 PostList 컴포넌트로 이동 => 컴포넌트 역할 예측, 재사용성 향상 효과
- `PostStorage` 관리로직 `storage/SessionStorage.ts` 모듈로 이동
- url 파싱 및 생성 로직을 `OptionQueryString`로 분리 및 구조화 => 응집성, 재사용성 향상 및 Home 컴포넌트 크기 감소

# 관련 이슈
- #112